### PR TITLE
HOTFIX - use `compile` command in the dependencies declaration

### DIFF
--- a/cameraDemo/build.gradle
+++ b/cameraDemo/build.gradle
@@ -62,8 +62,8 @@ android {
 }
 
 dependencies {
-    implementation project(":visearch-android")
-//    implementation ('com.visenze:visearch-android:1.4.0')
+//    implementation project(":visearch-android")
+    implementation ('com.visenze:visearch-android:1.5.3')
 
     implementation('androidx.appcompat:appcompat:1.0.0')
     implementation 'me.littlecheesecake:waterfalllayoutview:1.0.0'

--- a/visearch-android/build.gradle
+++ b/visearch-android/build.gradle
@@ -19,8 +19,8 @@ repositories {
 
 def versionMajor = 1
 def versionMinor = 5
-def versionPatch = 0
-version = '1.5.0'
+def versionPatch = 3
+version = '1.5.3'
 
 android {
     compileSdkVersion 28
@@ -47,8 +47,8 @@ configurations {
 }
 
 dependencies {
-    implementation ('com.android.volley:volley:1.1.1')
-    implementation 'com.visenze.datatracking:tracking:0.1.7'
+    compile 'com.android.volley:volley:1.1.1'
+    compile 'com.visenze.datatracking:tracking:0.1.7'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.8.9'


### PR DESCRIPTION
the reason is that the bintray publish gradle plugin only works with this deprecated command when generating the pom file. Will need to upgrade the publish tool in the future.