### PR TITLE
[PS-2130] Added ProductSearch example into the demo app 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 

--- a/cameraDemo/build.gradle
+++ b/cameraDemo/build.gradle
@@ -62,8 +62,8 @@ android {
 }
 
 dependencies {
-//    implementation project(":visearch-android")
-    implementation ('com.visenze:visearch-android:1.5.3')
+    implementation project(":visearch-android")
+    // implementation ('com.visenze:visearch-android:1.5.3')
 
     implementation('androidx.appcompat:appcompat:1.0.0')
     implementation 'me.littlecheesecake:waterfalllayoutview:1.0.0'
@@ -73,7 +73,6 @@ dependencies {
     implementation 'it.sephiroth.android.library.horizontallistview:hlistview:1.2.2'
     implementation 'com.jakewharton:butterknife:6.0.0'
     implementation 'com.squareup.picasso:picasso:2.4.0'
-    implementation project(path: ':visearch-android')
 
 
     testImplementation 'junit:junit:4.12'

--- a/cameraDemo/build.gradle
+++ b/cameraDemo/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 
@@ -73,6 +73,7 @@ dependencies {
     implementation 'it.sephiroth.android.library.horizontallistview:hlistview:1.2.2'
     implementation 'com.jakewharton:butterknife:6.0.0'
     implementation 'com.squareup.picasso:picasso:2.4.0'
+    implementation project(path: ':visearch-android')
 
 
     testImplementation 'junit:junit:4.12'

--- a/cameraDemo/build.gradle
+++ b/cameraDemo/build.gradle
@@ -62,8 +62,8 @@ android {
 }
 
 dependencies {
-    implementation project(":visearch-android")
-    // implementation ('com.visenze:visearch-android:1.5.3')
+    // implementation project(":visearch-android")
+    implementation ('com.visenze:visearch-android:1.5.3')
 
     implementation('androidx.appcompat:appcompat:1.0.0')
     implementation 'me.littlecheesecake:waterfalllayoutview:1.0.0'

--- a/cameraDemo/src/main/java/com/visenze/visearch/camerademo/MainActivity.java
+++ b/cameraDemo/src/main/java/com/visenze/visearch/camerademo/MainActivity.java
@@ -32,6 +32,7 @@ import com.visenze.visearch.camerademo.http.SearchAPI;
 public class MainActivity extends FragmentActivity {
     //TODO: init app key here
     private static final String appKey = "YOUR_APP_KEY";
+    private static final Integer placementId = 1; // only used in ProductSearch API/initializer
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -44,5 +45,6 @@ public class MainActivity extends FragmentActivity {
                 .commit();
 
         SearchAPI.initSearchAPI(this, appKey);
+        // SearchAPI.initProductSearchAPI(this, appKey, placementId);
     }
 }

--- a/cameraDemo/src/main/java/com/visenze/visearch/camerademo/fragments/CameraFragment.java
+++ b/cameraDemo/src/main/java/com/visenze/visearch/camerademo/fragments/CameraFragment.java
@@ -38,10 +38,14 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.Toast;
 
+import com.visenze.visearch.android.ProductSearch;
+import com.visenze.visearch.android.ProductSearchByImageParams;
 import com.visenze.visearch.android.ResultList;
 import com.visenze.visearch.android.UploadSearchParams;
 import com.visenze.visearch.android.ViSearch;
+import com.visenze.visearch.android.model.ErrorData;
 import com.visenze.visearch.android.model.Image;
+import com.visenze.visearch.android.model.ProductResponse;
 import com.visenze.visearch.camerademo.EditPhotoActivity;
 import com.visenze.visearch.camerademo.R;
 import com.visenze.visearch.camerademo.http.SearchAPI;
@@ -120,6 +124,7 @@ public class CameraFragment extends Fragment implements
                     R.id.camera_close_button})  List<ImageView>     cameraUIs;
     //ViSearch and Search parameters
     private ViSearch viSearch;
+    private ProductSearch productSearch;
     private String                      imagePath;
     private UploadSearchParams uploadSearchParams;
     //photo loading and process runnable
@@ -144,6 +149,7 @@ public class CameraFragment extends Fragment implements
 
         try {
             viSearch = SearchAPI.getInstance();
+            // productSearch = SearchAPI.getProductSearchInstance();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -198,6 +204,14 @@ public class CameraFragment extends Fragment implements
         DataHelper.setSearchParams(uploadSearchParams, "all");
 
         viSearch.uploadSearch(uploadSearchParams);
+
+        //ProductSearchByImageParams params = new ProductSearchByImageParams(image);
+        //productSearch.searchByImage(params, new ProductSearch.ResultListener() {
+        //    @Override
+        //   public void onSearchResult(ProductResponse response, ErrorData error) {
+        //        response.getProducts();
+        //    }
+        //});
     }
 
     /**

--- a/cameraDemo/src/main/java/com/visenze/visearch/camerademo/http/SearchAPI.java
+++ b/cameraDemo/src/main/java/com/visenze/visearch/camerademo/http/SearchAPI.java
@@ -26,6 +26,7 @@ package com.visenze.visearch.camerademo.http;
 
 import android.content.Context;
 
+import com.visenze.visearch.android.ProductSearch;
 import com.visenze.visearch.android.ViSearch;
 
 /**
@@ -34,14 +35,20 @@ import com.visenze.visearch.android.ViSearch;
  */
 public class SearchAPI {
     private static ViSearch viSearch;
-
+    private static ProductSearch productSearch;
 
     public static ViSearch getInstance() throws Exception {
         if (viSearch == null) {
             throw new Exception("init instance before use");
         }
-
         return viSearch;
+    }
+
+    public static ProductSearch getProductSearchInstance() throws Exception {
+        if (productSearch == null) {
+            throw new Exception("init instance before use");
+        }
+        return productSearch;
     }
 
     /**
@@ -52,5 +59,16 @@ public class SearchAPI {
      */
     public static void initSearchAPI(Context context, String appKey) {
         viSearch = new ViSearch.Builder(appKey).build(context);
+    }
+
+    /**
+     * Initialise the ProductSearcher with a valid access and placement ID
+     *
+     * @param context       Activity context
+     * @param appKey        the App Key
+     * @param placementId   the placement ID
+     */
+    public static void initProductSearchAPI(Context context, String appKey, Integer placementId) {
+        productSearch = new ProductSearch.Builder(appKey, placementId).build(context);
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 24 16:45:12 SGT 2019
+#Fri Apr 09 15:52:03 SGT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/visearch-android/build.gradle
+++ b/visearch-android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }


### PR DESCRIPTION
The example codes are in MainActivity, CameraFragment, SearchAPI classes. 
They are left commented out so that ViSearch is left as default first. 
The readme in [PS-2172] explains the example codes. 

Testing the SDK separately on test environment without an emulator possibly requires changes to the SDK. Speculation: Retrofit2 due to their Call<T>.enqueue not working without Android environment. Refer to: https://stackoverflow.com/questions/43117315/retrofit-enqueue-doesnt-work-but-execute-work.

[PS-2172]: https://visenze.atlassian.net/browse/PS-2172